### PR TITLE
Add Gornir constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ import (
 	"os"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
-	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"github.com/nornir-automation/gornir/pkg/plugins/output"
 	"github.com/nornir-automation/gornir/pkg/plugins/runner"
@@ -22,16 +21,16 @@ import (
 )
 
 func main() {
-	logger := logger.NewLogrus(false)
-
-	inventory, err := inventory.FromYAMLFile("/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml")
+	logger := logger.NewLogrus(false) 
+	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
+	
+	// Instantiate Gornir
+	gr, err := gornir.Build(
+		gornir.WithInventory(file),
+		gornir.WithLogger(logger),
+	)	
 	if err != nil {
 		logger.Fatal(err)
-	}
-
-	gr := &gornir.Gornir{
-		Inventory: inventory,
-		Logger:    logger,
 	}
 
 	results, err := gr.RunSync(

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ import (
 	"os"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
+	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"github.com/nornir-automation/gornir/pkg/plugins/output"
 	"github.com/nornir-automation/gornir/pkg/plugins/runner"
@@ -23,10 +24,11 @@ import (
 func main() {
 	logger := logger.NewLogrus(false) 
 	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
+	plugin := inventory.FromYAML{HostsFile: file}
 	
 	// Instantiate Gornir
 	gr, err := gornir.Build(
-		gornir.WithInventory(file),
+		gornir.WithInventory(plugin),
 		gornir.WithLogger(logger),
 	)	
 	if err != nil {

--- a/examples/1_simple/main.go
+++ b/examples/1_simple/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
+	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"github.com/nornir-automation/gornir/pkg/plugins/output"
 	"github.com/nornir-automation/gornir/pkg/plugins/runner"
@@ -16,10 +17,11 @@ func main() {
 	logger := logger.NewLogrus(false)
 	// File where the inventory will be loaded from.
 	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
+	plugin := inventory.FromYAML{HostsFile: file}
 
 	// Instantiate Gornir
 	gr, err := gornir.Build(
-		gornir.WithInventory(file),
+		gornir.WithInventory(plugin),
 		gornir.WithLogger(logger),
 	)
 	if err != nil {

--- a/examples/1_simple/main.go
+++ b/examples/1_simple/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	// Instantiate a logger plugin.
 	logger := logger.NewLogrus(false) 
-	// File where the inventory will be load from.
+	// File where the inventory will be loaded from.
 	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
 	
 	// Instantiate Gornir

--- a/examples/1_simple/main.go
+++ b/examples/1_simple/main.go
@@ -13,15 +13,15 @@ import (
 
 func main() {
 	// Instantiate a logger plugin.
-	logger := logger.NewLogrus(false) 
+	logger := logger.NewLogrus(false)
 	// File where the inventory will be loaded from.
 	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
-	
+
 	// Instantiate Gornir
 	gr, err := gornir.Build(
 		gornir.WithInventory(file),
 		gornir.WithLogger(logger),
-	)	
+	)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/examples/1_simple/main.go
+++ b/examples/1_simple/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
-	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"github.com/nornir-automation/gornir/pkg/plugins/output"
 	"github.com/nornir-automation/gornir/pkg/plugins/runner"
@@ -13,18 +12,18 @@ import (
 )
 
 func main() {
-	logger := logger.NewLogrus(false) // instantiate a logger plugin
-
-	// Load the inventory using the FromYAMLFile plugin
-	inventory, err := inventory.FromYAMLFile("/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml")
+	// Instantiate a logger plugin.
+	logger := logger.NewLogrus(false) 
+	// File where the inventory will be load from.
+	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
+	
+	// Instantiate Gornir
+	gr, err := gornir.Build(
+		gornir.WithInventory(file),
+		gornir.WithLogger(logger),
+	)	
 	if err != nil {
 		logger.Fatal(err)
-	}
-
-	// Instantiate Gornir
-	gr := &gornir.Gornir{
-		Inventory: inventory,
-		Logger:    logger,
 	}
 
 	// Following call is going to execute the task over all the hosts using the runner.Parallel runner.

--- a/examples/2_simple_with_filter/main.go
+++ b/examples/2_simple_with_filter/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
-	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"github.com/nornir-automation/gornir/pkg/plugins/output"
 	"github.com/nornir-automation/gornir/pkg/plugins/runner"
@@ -14,24 +13,26 @@ import (
 )
 
 func main() {
-	logger := logger.NewLogrus(false)
-
-	inventory, err := inventory.FromYAMLFile("/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml")
-	if err != nil {
-		logger.Fatal(err)
-	}
-
-	gr := &gornir.Gornir{
-		Inventory: inventory,
-		Logger:    logger,
-	}
-
+	// Instantiate a logger plugin.
+	logger := logger.NewLogrus(false) 
+	// File where the inventory will be loaded from.
+	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
 	// define a function we will use to filter the hosts
 	filter := func(ctx context.Context, h *gornir.Host) bool {
 		return h.Hostname == "dev1.group_1" || h.Hostname == "dev4.group_2"
 	}
 
-	// Before calling Gornir.RunS we call Gornir.Filter and pass the function defined
+	// Instantiate Gornir
+	gr, err := gornir.Build(
+		gornir.WithInventory(file),
+		gornir.WithLogger(logger),
+		gornir.WithFilter(filter),
+	)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	// Before calling Gornir.RunSync we call Gornir.Filter and pass the function defined
 	// above. This will narrow down the inventor to the hosts matching the filter
 	results, err := gr.Filter(context.Background(), filter).RunSync(
 		"What's my ip?",

--- a/examples/2_simple_with_filter/main.go
+++ b/examples/2_simple_with_filter/main.go
@@ -14,7 +14,7 @@ import (
 
 func main() {
 	// Instantiate a logger plugin.
-	logger := logger.NewLogrus(false) 
+	logger := logger.NewLogrus(false)
 	// File where the inventory will be loaded from.
 	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
 	// define a function we will use to filter the hosts

--- a/examples/2_simple_with_filter/main.go
+++ b/examples/2_simple_with_filter/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
+	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"github.com/nornir-automation/gornir/pkg/plugins/output"
 	"github.com/nornir-automation/gornir/pkg/plugins/runner"
@@ -17,6 +18,7 @@ func main() {
 	logger := logger.NewLogrus(false)
 	// File where the inventory will be loaded from.
 	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
+	plugin := inventory.FromYAML{HostsFile: file}
 	// define a function we will use to filter the hosts
 	filter := func(ctx context.Context, h *gornir.Host) bool {
 		return h.Hostname == "dev1.group_1" || h.Hostname == "dev4.group_2"
@@ -24,7 +26,7 @@ func main() {
 
 	// Instantiate Gornir
 	gr, err := gornir.Build(
-		gornir.WithInventory(file),
+		gornir.WithInventory(plugin),
 		gornir.WithLogger(logger),
 		gornir.WithFilter(filter),
 	)

--- a/examples/3_grouped_simple/main.go
+++ b/examples/3_grouped_simple/main.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
+	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"github.com/nornir-automation/gornir/pkg/plugins/output"
 	"github.com/nornir-automation/gornir/pkg/plugins/runner"
@@ -47,10 +48,11 @@ func main() {
 	logger := logger.NewLogrus(false)
 	// File where the inventory will be loaded from.
 	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
+	plugin := inventory.FromYAML{HostsFile: file}
 
 	// Instantiate Gornir
 	gr, err := gornir.Build(
-		gornir.WithInventory(file),
+		gornir.WithInventory(plugin),
 		gornir.WithLogger(logger),
 	)
 	if err != nil {

--- a/examples/3_grouped_simple/main.go
+++ b/examples/3_grouped_simple/main.go
@@ -44,15 +44,15 @@ func (c *checkMemoryAndCPU) Run(ctx context.Context, wg *sync.WaitGroup, jp *gor
 
 func main() {
 	// Instantiate a logger plugin.
-	logger := logger.NewLogrus(false) 
+	logger := logger.NewLogrus(false)
 	// File where the inventory will be loaded from.
 	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
-	
+
 	// Instantiate Gornir
 	gr, err := gornir.Build(
 		gornir.WithInventory(file),
 		gornir.WithLogger(logger),
-	)	
+	)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/examples/3_grouped_simple/main.go
+++ b/examples/3_grouped_simple/main.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
-	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"github.com/nornir-automation/gornir/pkg/plugins/output"
 	"github.com/nornir-automation/gornir/pkg/plugins/runner"
@@ -44,17 +43,18 @@ func (c *checkMemoryAndCPU) Run(ctx context.Context, wg *sync.WaitGroup, jp *gor
 }
 
 func main() {
-	// main is business as usual
-	logger := logger.NewLogrus(false)
-
-	inventory, err := inventory.FromYAMLFile("/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml")
+	// Instantiate a logger plugin.
+	logger := logger.NewLogrus(false) 
+	// File where the inventory will be loaded from.
+	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
+	
+	// Instantiate Gornir
+	gr, err := gornir.Build(
+		gornir.WithInventory(file),
+		gornir.WithLogger(logger),
+	)	
 	if err != nil {
 		logger.Fatal(err)
-	}
-
-	gr := &gornir.Gornir{
-		Inventory: inventory,
-		Logger:    logger,
 	}
 
 	results, err := gr.RunSync(

--- a/examples/4_advanced_1/main.go
+++ b/examples/4_advanced_1/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
+	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"github.com/nornir-automation/gornir/pkg/plugins/output"
 	"github.com/nornir-automation/gornir/pkg/plugins/runner"
@@ -17,10 +18,11 @@ func main() {
 	logger := logger.NewLogrus(false)
 	// File where the inventory will be loaded from.
 	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
+	plugin := inventory.FromYAML{HostsFile: file}
 
 	// Instantiate Gornir
 	gr, err := gornir.Build(
-		gornir.WithInventory(file),
+		gornir.WithInventory(plugin),
 		gornir.WithLogger(logger),
 	)
 	if err != nil {

--- a/examples/4_advanced_1/main.go
+++ b/examples/4_advanced_1/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
-	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"github.com/nornir-automation/gornir/pkg/plugins/output"
 	"github.com/nornir-automation/gornir/pkg/plugins/runner"
@@ -14,16 +13,18 @@ import (
 )
 
 func main() {
-	logger := logger.NewLogrus(false)
-
-	inventory, err := inventory.FromYAMLFile("/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml")
+	// Instantiate a logger plugin.
+	logger := logger.NewLogrus(false) 
+	// File where the inventory will be loaded from.
+	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
+	
+	// Instantiate Gornir
+	gr, err := gornir.Build(
+		gornir.WithInventory(file),
+		gornir.WithLogger(logger),
+	)	
 	if err != nil {
 		logger.Fatal(err)
-	}
-
-	gr := &gornir.Gornir{
-		Inventory: inventory,
-		Logger:    logger,
 	}
 
 	results := make(chan *gornir.JobResult, len(gr.Inventory.Hosts))

--- a/examples/4_advanced_1/main.go
+++ b/examples/4_advanced_1/main.go
@@ -14,15 +14,15 @@ import (
 
 func main() {
 	// Instantiate a logger plugin.
-	logger := logger.NewLogrus(false) 
+	logger := logger.NewLogrus(false)
 	// File where the inventory will be loaded from.
 	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
-	
+
 	// Instantiate Gornir
 	gr, err := gornir.Build(
 		gornir.WithInventory(file),
 		gornir.WithLogger(logger),
-	)	
+	)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/examples/5_advanced_2/main.go
+++ b/examples/5_advanced_2/main.go
@@ -15,15 +15,15 @@ import (
 
 func main() {
 	// Instantiate a logger plugin.
-	logger := logger.NewLogrus(false) 
+	logger := logger.NewLogrus(false)
 	// File where the inventory will be loaded from.
 	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
-	
+
 	// Instantiate Gornir
 	gr, err := gornir.Build(
 		gornir.WithInventory(file),
 		gornir.WithLogger(logger),
-	)	
+	)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/examples/5_advanced_2/main.go
+++ b/examples/5_advanced_2/main.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
+	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"github.com/nornir-automation/gornir/pkg/plugins/runner"
 	"github.com/nornir-automation/gornir/pkg/plugins/task"
@@ -18,10 +19,11 @@ func main() {
 	logger := logger.NewLogrus(false)
 	// File where the inventory will be loaded from.
 	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
+	plugin := inventory.FromYAML{HostsFile: file}
 
 	// Instantiate Gornir
 	gr, err := gornir.Build(
-		gornir.WithInventory(file),
+		gornir.WithInventory(plugin),
 		gornir.WithLogger(logger),
 	)
 	if err != nil {

--- a/examples/5_advanced_2/main.go
+++ b/examples/5_advanced_2/main.go
@@ -8,23 +8,24 @@ import (
 	"time"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
-	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"github.com/nornir-automation/gornir/pkg/plugins/runner"
 	"github.com/nornir-automation/gornir/pkg/plugins/task"
 )
 
 func main() {
-	logger := logger.NewLogrus(false)
-
-	inventory, err := inventory.FromYAMLFile("/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml")
+	// Instantiate a logger plugin.
+	logger := logger.NewLogrus(false) 
+	// File where the inventory will be loaded from.
+	file := "/go/src/github.com/nornir-automation/gornir/examples/hosts.yaml"
+	
+	// Instantiate Gornir
+	gr, err := gornir.Build(
+		gornir.WithInventory(file),
+		gornir.WithLogger(logger),
+	)	
 	if err != nil {
 		logger.Fatal(err)
-	}
-
-	gr := &gornir.Gornir{
-		Inventory: inventory,
-		Logger:    logger,
 	}
 
 	results := make(chan *gornir.JobResult, len(gr.Inventory.Hosts))

--- a/pkg/gornir/gornir.go
+++ b/pkg/gornir/gornir.go
@@ -1,4 +1,4 @@
-// Package gornir implements the core functionality and define the needed 
+// Package gornir implements the core functionality and define the needed
 // interfaces to integrate with the framework
 package gornir
 
@@ -44,7 +44,7 @@ func WithInventory(f string) SetOption {
 	return func(g *Gornir) error {
 		inv, err := fromYAMLFile(f)
 		if err != nil {
-			return errors.Wrap(err, "could not read inventory from file " + f)
+			return errors.Wrap(err, "could not read inventory from file "+f)
 		}
 		g.Inventory = inv
 		return nil

--- a/pkg/gornir/gornir.go
+++ b/pkg/gornir/gornir.go
@@ -1,19 +1,105 @@
-// Package Gornir implements the core functionality and define the needed interfaces to integrate with the framework
+// Package gornir implements the core functionality and define the needed 
+// interfaces to integrate with the framework
 package gornir
 
 import (
 	"context"
+	"io/ioutil"
 	"reflect"
 	"runtime"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 )
 
 // Gornir is the main object that glues everything together
 type Gornir struct {
 	Inventory *Inventory // Inventory for the object
 	Logger    Logger     // Logger for the object
+}
+
+// NewGornir is a Gornir constructor.
+func NewGornir() *Gornir {
+	return new(Gornir)
+}
+
+// SetOption is a funcion that sets one or more options for a given Gornir.
+type SetOption func(r *Gornir) error
+
+// Build is a Gornir constructor with options.
+func Build(opts ...SetOption) (*Gornir, error) {
+	var gornir Gornir
+	for _, opt := range opts {
+		err := opt(&gornir)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &gornir, nil
+}
+
+// WithInventory reads the inventory from a file for a Gornir.
+func WithInventory(f string) SetOption {
+	return func(g *Gornir) error {
+		inv, err := fromYAMLFile(f)
+		if err != nil {
+			return errors.Wrap(err, "could not read inventory from file " + f)
+		}
+		g.Inventory = inv
+		return nil
+	}
+}
+
+// fromYAMLFile will instantiate the inventory from a YAML file. The
+// contents of the YAML file follow the same structure as the structs
+// but in lower case. For instance:
+//     dev1.group_1:
+//         port: 22
+//         hostname: dev1.group_1
+//         username: root
+//         password: docker
+//
+//     dev2.group_1:
+//         port: 22
+//         hostname: dev2.group_1
+//         username: root
+//         password: docker
+func fromYAMLFile(hostsFile string) (*Inventory, error) {
+	b, err := ioutil.ReadFile(hostsFile)
+	if err != nil {
+		return &Inventory{}, errors.Wrap(err, "problem reading hosts file")
+	}
+	hosts := make(map[string]*Host)
+	err = yaml.Unmarshal(b, hosts)
+	if err != nil {
+		return &Inventory{}, errors.Wrap(err, "problem unmarshalling yaml")
+	}
+	return &Inventory{
+		Hosts: hosts,
+	}, nil
+}
+
+// WithLogger sets the logging option for a Gornir.
+func WithLogger(l Logger) SetOption {
+	return func(g *Gornir) error {
+		if l == nil {
+			errors.New("didn't receive a valid logger")
+		}
+		g.Logger = l
+		return nil
+	}
+}
+
+// WithFilter provides a FilterFunc to a Gornir to filter the list of hosts.
+func WithFilter(f FilterFunc) SetOption {
+	return func(g *Gornir) error {
+		if f == nil {
+			errors.New("didn't receive a valid filter function")
+		}
+		g.Inventory = g.Inventory.Filter(context.TODO(), f)
+		return nil
+	}
 }
 
 // Filter filters the hosts in the inventory returning a copy of the current

--- a/pkg/gornir/gornir.go
+++ b/pkg/gornir/gornir.go
@@ -78,14 +78,14 @@ func WithFilter(f FilterFunc) SetOption {
 }
 
 // Build constructs a new Gornir from an existing one.
-func (gr *Gornir) Build(opts ...SetOption) (*Gornir, error) {
+func (gr Gornir) Build(opts ...SetOption) (*Gornir, error) {
 	for _, opt := range opts {
-		err := opt(gr)
+		err := opt(&gr)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return gr, nil
+	return &gr, nil
 }
 
 // Filter filters the hosts in the inventory returning a copy of the current

--- a/pkg/gornir/gornir_test.go
+++ b/pkg/gornir/gornir_test.go
@@ -2,10 +2,11 @@ package gornir_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/nornir-automation/gornir/pkg/gornir"
 	inv "github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	log "github.com/nornir-automation/gornir/pkg/plugins/logger"
-	"testing"
 )
 
 var (
@@ -66,6 +67,8 @@ func TestBuild(t *testing.T) {
 				gornir.WithInventory(plugin),
 				gornir.WithLogger(logger),
 			)
+			olen := len(original.Inventory.Hosts)
+
 			if err != nil {
 				t.Fatalf("could not build a Gornir from file '%s' in Test Case '%s'. Error: '%v'",
 					tc.input, tc.name, err)
@@ -76,8 +79,12 @@ func TestBuild(t *testing.T) {
 					tc.name, err)
 			}
 			if len(filtered.Inventory.Hosts) != tc.length {
-				t.Fatalf("Inventory Length in Test Case '%s' is %v, want %v",
+				t.Fatalf("Filtered Inventory Length in Test Case '%s' is %v, want %v",
 					tc.name, len(filtered.Inventory.Hosts), tc.length)
+			}
+			if len(original.Inventory.Hosts) != olen {
+				t.Fatalf("Oringinal Inventory Length in Test Case '%s' is %v, want %v",
+					tc.name, len(original.Inventory.Hosts), olen)
 			}
 		})
 	}

--- a/pkg/gornir/gornir_test.go
+++ b/pkg/gornir/gornir_test.go
@@ -1,7 +1,9 @@
 package gornir_test
 
 import (
+	"context"
 	"github.com/nornir-automation/gornir/pkg/gornir"
+	inv "github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	log "github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"testing"
 )
@@ -9,10 +11,10 @@ import (
 var (
 	file      = "../../examples/hosts.yaml"
 	logger    = log.NewLogrus(false)
-	noFileErr = "could not read inventory from file : problem reading hosts file: open : no such file or directory"
+	noFileErr = "could not read inventory from plugin: problem reading hosts file: open : no such file or directory"
 )
 
-func TestBuild(t *testing.T) {
+func TestRead(t *testing.T) {
 	tt := []struct {
 		name  string
 		input string
@@ -23,9 +25,10 @@ func TestBuild(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			// Instantiate Gornir
+			plugin := inv.FromYAML{HostsFile: tc.input}
+
 			_, err := gornir.Build(
-				gornir.WithInventory(tc.input),
+				gornir.WithInventory(plugin),
 				gornir.WithLogger(logger),
 			)
 			if err != nil {
@@ -33,6 +36,48 @@ func TestBuild(t *testing.T) {
 					t.Fatalf("could not build a Gornir from file '%s' in Test Case '%s'. Error: '%v'",
 						tc.input, tc.name, err)
 				}
+			}
+		})
+	}
+}
+
+func TestBuild(t *testing.T) {
+	f1 := func(ctx context.Context, h *gornir.Host) bool {
+		return h.Hostname == "dev1.group_1" || h.Hostname == "dev4.group_2"
+	}
+	f2 := func(ctx context.Context, h *gornir.Host) bool {
+		return h.Hostname == "uknownk"
+	}
+	tt := []struct {
+		name   string
+		input  string
+		err    string
+		filter gornir.FilterFunc
+		length int
+	}{
+		{name: "With Filter 1", input: file, filter: f1, length: 2},
+		{name: "With Filter 2", input: file, filter: f2, length: 0},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			plugin := inv.FromYAML{HostsFile: tc.input}
+
+			original, err := gornir.Build(
+				gornir.WithInventory(plugin),
+				gornir.WithLogger(logger),
+			)
+			if err != nil {
+				t.Fatalf("could not build a Gornir from file '%s' in Test Case '%s'. Error: '%v'",
+					tc.input, tc.name, err)
+			}
+			filtered, err := original.Build(gornir.WithFilter(tc.filter))
+			if err != nil {
+				t.Fatalf("could not build a Filtered Gornir in Test Case '%s'. Error: '%v'",
+					tc.name, err)
+			}
+			if len(filtered.Inventory.Hosts) != tc.length {
+				t.Fatalf("Inventory Length in Test Case '%s' is %v, want %v",
+					tc.name, len(filtered.Inventory.Hosts), tc.length)
 			}
 		})
 	}

--- a/pkg/gornir/gornir_test.go
+++ b/pkg/gornir/gornir_test.go
@@ -1,0 +1,39 @@
+package gornir_test
+
+import (
+	"github.com/nornir-automation/gornir/pkg/gornir"
+	log "github.com/nornir-automation/gornir/pkg/plugins/logger"
+	"testing"
+)
+
+var (
+	file      = "../../examples/hosts.yaml"
+	logger    = log.NewLogrus(false)
+	noFileErr = "could not read inventory from file : problem reading hosts file: open : no such file or directory"
+)
+
+func TestBuild(t *testing.T) {
+	tt := []struct {
+		name  string
+		input string
+		err   string
+	}{
+		{name: "From YAML", input: file},
+		{name: "From no file", input: "", err: noFileErr},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			// Instantiate Gornir
+			_, err := gornir.Build(
+				gornir.WithInventory(tc.input),
+				gornir.WithLogger(logger),
+			)
+			if err != nil {
+				if err.Error() != tc.err {
+					t.Fatalf("could not build a Gornir from file '%s' in Test Case '%s'. Error: '%v'",
+						tc.input, tc.name, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/plugins/inventory/yaml.go
+++ b/pkg/plugins/inventory/yaml.go
@@ -9,9 +9,13 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// FromYAMLFile will instantiate the inventory from a YAML file. The
-// contents of the YAML file follow the same structure as the structs
-// but in lower case. For instance:
+// FromYAML satisfies the InventoryPlugin interface for YAML files.
+type FromYAML struct {
+	HostsFile string
+}
+
+// Create parses the content of a YAML file follwoing the same structure
+// as the structs, but in lower case to create an Inventory. For instance:
 //     dev1.group_1:
 //         port: 22
 //         hostname: dev1.group_1
@@ -23,18 +27,18 @@ import (
 //         hostname: dev2.group_1
 //         username: root
 //         password: docker
-func FromYAMLFile(hostsFile string) (*gornir.Inventory, error) {
-	b, err := ioutil.ReadFile(hostsFile)
+func (f FromYAML) Create() (gornir.Inventory, error) {
+	b, err := ioutil.ReadFile(f.HostsFile)
 	if err != nil {
-		return &gornir.Inventory{}, errors.Wrap(err, "problem reading hosts file")
+		return gornir.Inventory{}, errors.Wrap(err, "problem reading hosts file")
 	}
 	hosts := make(map[string]*gornir.Host)
 	err = yaml.Unmarshal(b, hosts)
 	if err != nil {
-		return &gornir.Inventory{}, errors.Wrap(err, "problem unmarshalling yaml")
+		return gornir.Inventory{}, errors.Wrap(err, "problem unmarshalling yaml")
 	}
 
-	return &gornir.Inventory{
+	return gornir.Inventory{
 		Hosts: hosts,
 	}, nil
 }


### PR DESCRIPTION
This is work in progress. I got rid of `pkg/plugins/inventory` to avoid a circular dependency, therefore I moved `fromYAMLFile` to gornir package and made it an unexported function; users would need to use `WithInventory` instead.

- [x] Create Constructor/Build function
- [x] Update Examples
- [x] Add test cases
- [x] Update Readme file


