### PR TITLE
Add YAML inventory benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage.txt
 examples/output.txt
 
 vendor/
+**/.DS_Store

--- a/pkg/plugins/inventory/testdata/hosts.yaml
+++ b/pkg/plugins/inventory/testdata/hosts.yaml
@@ -1,0 +1,30 @@
+---
+dev1.group_1:
+    port: 22
+    hostname: dev1.group_1
+    username: root
+    password: docker
+
+dev2.group_1:
+    port: 22
+    hostname: dev2.group_1
+    username: root
+    password: docker
+
+dev3.group_2:
+    port: 22
+    hostname: dev3.group_2
+    username: root
+    password: docker
+
+dev4.group_2:
+    port: 22
+    hostname: dev4.group_2
+    username: root
+    password: docker
+
+dev5.no_group:
+    port: 22
+    hostname: dev5.no_group
+    username: root
+    password: WRONG!!!

--- a/pkg/plugins/inventory/testdata/inchosts
+++ b/pkg/plugins/inventory/testdata/inchosts
@@ -1,0 +1,13 @@
+---
+dev1.group_1:
+    port: 22
+    hostname: dev1.group_1
+    username: root
+    password: docker
+
+dev2.group_1:
+    port: 22
+  hostname: dev2.group_1
+    username: root
+    password: docker
+

--- a/pkg/plugins/inventory/yaml_test.go
+++ b/pkg/plugins/inventory/yaml_test.go
@@ -1,0 +1,51 @@
+package inventory_test
+
+import (
+	"testing"
+
+	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
+)
+
+var (
+	file          = "testdata/hosts.yaml"
+	noFileErr     = "problem reading hosts file: open : no such file or directory"
+	incorrectYAML = "testdata/inchosts"
+	incYAMLErr    = "problem unmarshalling yaml: yaml: line 9: did not find expected key"
+)
+
+func TestCreate(t *testing.T) {
+	tt := []struct {
+		name  string
+		input string
+		err   string
+	}{
+		{name: "From YAML file", input: file},
+		{name: "From no file", input: "", err: noFileErr},
+		{name: "From Incorrect YAML", input: incorrectYAML, err: incYAMLErr},
+	}
+	for _, tc := range tt {
+		tc := tc // lock the variable. This is a problem of golint, we don't need this here.
+		t.Run(tc.name, func(t *testing.T) {
+			plugin := inventory.FromYAML{HostsFile: tc.input}
+			_, err := plugin.Create()
+
+			if err != nil {
+				if err.Error() != tc.err {
+					t.Fatalf("could not read an inventory from file '%s' in Test Case '%s'. Error: '%v'",
+						tc.input, tc.name, err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkCreate(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		plugin := inventory.FromYAML{HostsFile: file}
+		_, err := plugin.Create()
+		if err != nil {
+			b.Fatalf("could not read an inventory from file '%s' in Benchmark", file)
+		}
+		// _ = gornir.New().WithInventory(inv)
+	}
+}


### PR DESCRIPTION
Adding a new test file in `pkg/plugins/inventory`. The goal is to include a Benchmark that shows the runtime and memory allocation of the function `Create()` when reading from a YAML file.

I put the test input data in a new folder `testdata`. I took the idea from this [post](https://medium.com/@povilasve/go-advanced-tips-tricks-a872503ac859#c8ea)

To run the bechmark:

```bash
$ go test -run=XXX -bench=. -benchmem ./pkg/plugins/inventory
goos: darwin
goarch: amd64
pkg: github.com/nornir-automation/gornir/pkg/plugins/inventory
BenchmarkCreate-8   	   20000	     82806 ns/op	   16059 B/op	     281 allocs/op
PASS
ok  	github.com/nornir-automation/gornir/pkg/plugins/inventory	2.569s
```