### PR TITLE
WIP Reuse connections to devices

### DIFF
--- a/examples/1_simple/main.go
+++ b/examples/1_simple/main.go
@@ -61,7 +61,7 @@ func main() {
 	// next call is going to print the result on screen
 	output.RenderResults(os.Stdout, results, "What is my ip?", true)
 
-	// Now we upload a file. This shows how ssh connection is shared across tasks and even plugins
+	// Now we upload a file. This shows how the ssh connection is shared across tasks of same or different type
 	results, err = gr.RunSync(
 		&task.SFTPUpload{Src: "/etc/hosts", Dst: "/tmp/asd"},
 	)

--- a/examples/1_simple/main.go
+++ b/examples/1_simple/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
+	"github.com/nornir-automation/gornir/pkg/plugins/connection"
 	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"github.com/nornir-automation/gornir/pkg/plugins/output"
@@ -28,17 +29,52 @@ func main() {
 
 	gr := gornir.New().WithInventory(inv).WithLogger(log).WithRunner(rnr)
 
+	results, err := gr.RunSync(
+		"Connect to devices via ssh",
+		&connection.SSHOpen{},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	output.RenderResults(os.Stdout, results, true)
+
 	// Following call is going to execute the task over all the hosts using the runner.Parallel runner.
 	// Said runner is going to handle the parallelization for us. Gornir.RunS is also going to block
 	// until the runner has completed executing the task over all the hosts
-	results, err := gr.RunSync(
+	results, err = gr.RunSync(
 		"What's my ip?",
 		&task.RemoteCommand{Command: "ip addr | grep \\/24 | awk '{ print $2 }'"},
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
-
 	// next call is going to print the result on screen
+	output.RenderResults(os.Stdout, results, true)
+
+	results, err = gr.RunSync(
+		"What's my ip? (II)",
+		&task.RemoteCommand{Command: "ip addr | grep \\/24 | awk '{ print $2 }'"},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	output.RenderResults(os.Stdout, results, true)
+
+	results, err = gr.RunSync(
+		"Upload File",
+		&task.SFTPUpload{Src: "/etc/hosts", Dst: "/tmp/asd"},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	output.RenderResults(os.Stdout, results, true)
+
+	results, err = gr.RunSync(
+		"Close ssh connection",
+		&connection.SSHClose{},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
 	output.RenderResults(os.Stdout, results, true)
 }

--- a/examples/1_simple/output.txt
+++ b/examples/1_simple/output.txt
@@ -1,50 +1,56 @@
-go: finding github.com/pkg/sftp v1.10.0
-go: finding github.com/kr/fs v0.1.0
-go: downloading github.com/pkg/sftp v1.10.0
-go: extracting github.com/pkg/sftp v1.10.0
-go: downloading github.com/kr/fs v0.1.0
-go: extracting github.com/kr/fs v0.1.0
 [34m# Connecting to devices via ssh
 [0m[32m@ dev1.group_1
-[0m&{%!s(*ssh.Client=&{0xc000014380 {{0 0} 0} {{0 0} []} {0 0} map[]})}
+[0m  - connection opened
 [32m@ dev2.group_1
-[0m&{%!s(*ssh.Client=&{0xc000110380 {{0 0} 0} {{0 0} []} {0 0} map[]})}
+[0m  - connection opened
 [32m@ dev3.group_2
-[0m&{%!s(*ssh.Client=&{0xc000014700 {{0 0} 0} {{0 0} []} {0 0} map[]})}
+[0m  - connection opened
 [32m@ dev4.group_2
-[0m&{%!s(*ssh.Client=&{0xc00016c300 {{0 0} 0} {{0 0} []} {0 0} map[]})}
+[0m  - connection opened
 [31m@ dev5.no_group
-[0m  - err: failed to dial: ssh: handshake failed: ssh: unable to authenticate, attempted methods [password none], no supported methods remain
+[0m  - err: failed to dial: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none password], no supported methods remain
 
 [34m# What is my ip?
-[0m[31m@ dev1.group_1
-[0m  - err: failed to retrieve connection: there are no connection established
+[0m[32m@ dev1.group_1
+[0m  - stdout: 10.21.33.101/24
 
-[31m@ dev2.group_1
-[0m  - err: failed to retrieve connection: there are no connection established
+  - stderr: 
+[32m@ dev2.group_1
+[0m  - stdout: 10.21.33.102/24
 
-[31m@ dev3.group_2
-[0m  - err: failed to retrieve connection: there are no connection established
+  - stderr: 
+[32m@ dev3.group_2
+[0m  - stdout: 10.21.33.103/24
 
-[31m@ dev4.group_2
-[0m  - err: failed to retrieve connection: there are no connection established
+  - stderr: 
+[32m@ dev4.group_2
+[0m  - stdout: 10.21.33.104/24
 
+  - stderr: 
 [31m@ dev5.no_group
-[0m  - err: failed to retrieve connection: there are no connection established
+[0m  - err: failed to retrieve connection: couldn't find connection
+
+[34m# Upload File
+[0m[32m@ dev1.group_1
+[0m  - uploaded: 326 bytes
+[32m@ dev2.group_1
+[0m  - uploaded: 326 bytes
+[32m@ dev3.group_2
+[0m  - uploaded: 326 bytes
+[32m@ dev4.group_2
+[0m  - uploaded: 326 bytes
+[31m@ dev5.no_group
+[0m  - err: failed to retrieve connection: couldn't find connection
 
 [34m# Close ssh connection
-[0m[31m@ dev1.group_1
-[0m  - err: failed to retrieve connection: there are no connection established
-
-[31m@ dev2.group_1
-[0m  - err: failed to retrieve connection: there are no connection established
-
-[31m@ dev3.group_2
-[0m  - err: failed to retrieve connection: there are no connection established
-
-[31m@ dev4.group_2
-[0m  - err: failed to retrieve connection: there are no connection established
-
+[0m[32m@ dev1.group_1
+[0m  - connection closed
+[32m@ dev2.group_1
+[0m  - connection closed
+[32m@ dev3.group_2
+[0m  - connection closed
+[32m@ dev4.group_2
+[0m  - connection closed
 [31m@ dev5.no_group
-[0m  - err: failed to retrieve connection: there are no connection established
+[0m  - err: failed to retrieve connection: couldn't find connection
 

--- a/examples/1_simple/output.txt
+++ b/examples/1_simple/output.txt
@@ -1,3 +1,25 @@
+go: finding github.com/kr/fs v0.1.0
+go: finding github.com/pkg/sftp v1.10.0
+go: downloading github.com/pkg/sftp v1.10.0
+go: extracting github.com/pkg/sftp v1.10.0
+go: downloading github.com/kr/fs v0.1.0
+go: extracting github.com/kr/fs v0.1.0
+[34m# Connect to devices via ssh
+[0m[32m@ dev1.group_1
+[0m  - err: <nil>
+
+[32m@ dev2.group_1
+[0m  - err: <nil>
+
+[32m@ dev3.group_2
+[0m  - err: <nil>
+
+[32m@ dev4.group_2
+[0m  - err: <nil>
+
+[31m@ dev5.no_group
+[0m  - err: failed to dial: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none password], no supported methods remain
+
 [34m# What's my ip?
 [0m[32m@ dev1.group_1
 [0m * Stdout: 10.21.33.101/24
@@ -24,5 +46,69 @@
   - err: <nil>
 
 [31m@ dev5.no_group
-[0m  - err: failed to dial: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none password], no supported methods remain
+[0m  - err: failed to retrieve connection: there are no connection established
+
+[34m# What's my ip? (II)
+[0m[32m@ dev1.group_1
+[0m * Stdout: 10.21.33.101/24
+
+ * Stderr: 
+  - err: <nil>
+
+[32m@ dev2.group_1
+[0m * Stdout: 10.21.33.102/24
+
+ * Stderr: 
+  - err: <nil>
+
+[32m@ dev3.group_2
+[0m * Stdout: 10.21.33.103/24
+
+ * Stderr: 
+  - err: <nil>
+
+[32m@ dev4.group_2
+[0m * Stdout: 10.21.33.104/24
+
+ * Stderr: 
+  - err: <nil>
+
+[31m@ dev5.no_group
+[0m  - err: failed to retrieve connection: there are no connection established
+
+[34m# Upload File
+[0m[32m@ dev1.group_1
+[0m * Bytes: %!s(int64=326)
+  - err: <nil>
+
+[32m@ dev2.group_1
+[0m * Bytes: %!s(int64=326)
+  - err: <nil>
+
+[32m@ dev3.group_2
+[0m * Bytes: %!s(int64=326)
+  - err: <nil>
+
+[32m@ dev4.group_2
+[0m * Bytes: %!s(int64=326)
+  - err: <nil>
+
+[31m@ dev5.no_group
+[0m  - err: failed to retrieve connection: there are no connection established
+
+[34m# Close ssh connection
+[0m[32m@ dev1.group_1
+[0m  - err: <nil>
+
+[32m@ dev2.group_1
+[0m  - err: <nil>
+
+[32m@ dev3.group_2
+[0m  - err: <nil>
+
+[32m@ dev4.group_2
+[0m  - err: <nil>
+
+[31m@ dev5.no_group
+[0m  - err: failed to retrieve connection: there are no connection established
 

--- a/examples/2_simple_with_filter/output.txt
+++ b/examples/2_simple_with_filter/output.txt
@@ -1,3 +1,8 @@
+[34m# Connecting to devices via ssh
+[0m[32m@ dev1.group_1
+[0m  - connection opened
+[32m@ dev4.group_2
+[0m  - connection opened
 [34m# What's my ip?
 [0m[32m@ dev1.group_1
 [0m  - stdout: 10.21.33.101/24
@@ -7,3 +12,8 @@
 [0m  - stdout: 10.21.33.104/24
 
   - stderr: 
+[34m# Close ssh connection
+[0m[32m@ dev1.group_1
+[0m  - connection closed
+[32m@ dev4.group_2
+[0m  - connection closed

--- a/examples/2_simple_with_filter_bis/main.go
+++ b/examples/2_simple_with_filter_bis/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
+	"github.com/nornir-automation/gornir/pkg/plugins/connection"
 	f "github.com/nornir-automation/gornir/pkg/plugins/filter"
 	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
@@ -30,9 +31,34 @@ func main() {
 
 	gr := gornir.New().WithInventory(inv).WithLogger(log).WithRunner(runner.Sorted())
 
+	// Before calling any method we created a filtered version of our gr object.
+	// The original object is left unmodified. Now we can use this filtered
+	// object to execute our tasks in a subset of our devices
+	filteredGr := gr.Filter(filter)
+
+	// Open an SSH connection towards the devices
+	results, err := filteredGr.RunSync(
+		&connection.SSHOpen{},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	output.RenderResults(os.Stdout, results, "Connecting to devices via ssh", true)
+
+	// defer closing the SSH connection we just opened
+	defer func() {
+		results, err = filteredGr.RunSync(
+			&connection.SSHClose{},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		output.RenderResults(os.Stdout, results, "Close ssh connection", true)
+	}()
+
 	// Before calling Gornir.RunS we call Gornir.Filter and pass the function defined
 	// above. This will narrow down the inventor to the hosts matching the filter
-	results, err := gr.Filter(filter).RunSync(
+	results, err = filteredGr.Filter(filter).RunSync(
 		&task.RemoteCommand{Command: "ip addr | grep \\/24 | awk '{ print $2 }'"},
 	)
 	if err != nil {

--- a/examples/2_simple_with_filter_bis/output.txt
+++ b/examples/2_simple_with_filter_bis/output.txt
@@ -1,7 +1,19 @@
+[34m# Connecting to devices via ssh
+[0m[32m@ dev1.group_1
+[0m  - connection opened
+[32m@ dev4.group_2
+[0m  - connection opened
 [34m# What's my ip?
-[0m[31m@ dev1.group_1
-[0m  - err: failed to retrieve connection: couldn't find connection
+[0m[32m@ dev1.group_1
+[0m  - stdout: 10.21.33.101/24
 
-[31m@ dev4.group_2
-[0m  - err: failed to retrieve connection: couldn't find connection
+  - stderr: 
+[32m@ dev4.group_2
+[0m  - stdout: 10.21.33.104/24
 
+  - stderr: 
+[34m# Close ssh connection
+[0m[32m@ dev1.group_1
+[0m  - connection closed
+[32m@ dev4.group_2
+[0m  - connection closed

--- a/examples/2_simple_with_filter_bis/output.txt
+++ b/examples/2_simple_with_filter_bis/output.txt
@@ -1,9 +1,7 @@
 [34m# What's my ip?
-[0m[32m@ dev1.group_1
-[0m  - stdout: 10.21.33.101/24
+[0m[31m@ dev1.group_1
+[0m  - err: failed to retrieve connection: couldn't find connection
 
-  - stderr: 
-[32m@ dev4.group_2
-[0m  - stdout: 10.21.33.104/24
+[31m@ dev4.group_2
+[0m  - err: failed to retrieve connection: couldn't find connection
 
-  - stderr: 

--- a/examples/3_grouped_simple/main.go
+++ b/examples/3_grouped_simple/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
+	"github.com/nornir-automation/gornir/pkg/plugins/connection"
 	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"github.com/nornir-automation/gornir/pkg/plugins/output"
@@ -63,7 +64,27 @@ func main() {
 
 	gr := gornir.New().WithInventory(inv).WithLogger(log).WithRunner(rnr)
 
+	// Open an SSH connection towards the devices
 	results, err := gr.RunSync(
+		&connection.SSHOpen{},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	output.RenderResults(os.Stdout, results, "Connecting to devices via ssh", true)
+
+	// defer closing the SSH connection we just opened
+	defer func() {
+		results, err = gr.RunSync(
+			&connection.SSHClose{},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		output.RenderResults(os.Stdout, results, "Close ssh connection", true)
+	}()
+
+	results, err = gr.RunSync(
 		&getHostnameAndIP{},
 	)
 	if err != nil {

--- a/examples/3_grouped_simple/main.go
+++ b/examples/3_grouped_simple/main.go
@@ -84,6 +84,9 @@ func main() {
 		output.RenderResults(os.Stdout, results, "Close ssh connection", true)
 	}()
 
+	// Now we call our "grouped task", which is just a task that uses other tasks
+	// In this example we are managing the connection outside the grouped task
+	// but we could easily move that inside the grouped task
 	results, err = gr.RunSync(
 		&getHostnameAndIP{},
 	)

--- a/examples/3_grouped_simple/output.txt
+++ b/examples/3_grouped_simple/output.txt
@@ -1,3 +1,15 @@
+[34m# Connecting to devices via ssh
+[0m[32m@ dev1.group_1
+[0m  - connection opened
+[32m@ dev2.group_1
+[0m  - connection opened
+[32m@ dev3.group_2
+[0m  - connection opened
+[32m@ dev4.group_2
+[0m  - connection opened
+[31m@ dev5.no_group
+[0m  - err: failed to dial: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none password], no supported methods remain
+
 [34m# Let's run a couple of commands
 [0m[32m@ dev1.group_1
 [0m  - hostname: dev1.group_1
@@ -16,5 +28,17 @@
   - ip address: 10.21.33.104/24
 
 [31m@ dev5.no_group
-[0m  - err: failed to dial: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none password], no supported methods remain
+[0m  - err: failed to retrieve connection: couldn't find connection
+
+[34m# Close ssh connection
+[0m[32m@ dev1.group_1
+[0m  - connection closed
+[32m@ dev2.group_1
+[0m  - connection closed
+[32m@ dev3.group_2
+[0m  - connection closed
+[32m@ dev4.group_2
+[0m  - connection closed
+[31m@ dev5.no_group
+[0m  - err: failed to retrieve connection: couldn't find connection
 

--- a/examples/4_advanced_1/main.go
+++ b/examples/4_advanced_1/main.go
@@ -52,6 +52,7 @@ func main() {
 		output.RenderResults(os.Stdout, results, "Close ssh connection", true)
 	}()
 
+	// We need a channel to store the results
 	res := make(chan *gornir.JobResult, len(gr.Inventory.Hosts))
 
 	// Gornir.RunAsync doesn't block so it's up to the user to check the runner is done

--- a/examples/4_advanced_1/main.go
+++ b/examples/4_advanced_1/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
+	"github.com/nornir-automation/gornir/pkg/plugins/connection"
 	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"github.com/nornir-automation/gornir/pkg/plugins/output"
@@ -31,13 +32,33 @@ func main() {
 
 	gr := gornir.New().WithInventory(inv).WithLogger(log).WithRunner(rnr)
 
-	results := make(chan *gornir.JobResult, len(gr.Inventory.Hosts))
+	// Open an SSH connection towards the devices
+	results, err := gr.RunSync(
+		&connection.SSHOpen{},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	output.RenderResults(os.Stdout, results, "Connecting to devices via ssh", true)
+
+	// defer closing the SSH connection we just opened
+	defer func() {
+		results, err = gr.RunSync(
+			&connection.SSHClose{},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		output.RenderResults(os.Stdout, results, "Close ssh connection", true)
+	}()
+
+	res := make(chan *gornir.JobResult, len(gr.Inventory.Hosts))
 
 	// Gornir.RunAsync doesn't block so it's up to the user to check the runner is done
 	err = gr.RunAsync(
 		context.Background(),
 		&task.RemoteCommand{Command: "hostname"},
-		results,
+		res,
 	)
 	if err != nil {
 		log.Fatal(err)
@@ -46,6 +67,6 @@ func main() {
 	// Next call will block until the runner is done
 	rnr.Wait()
 
-	close(results) // we need to close the channel or output.RenderResults will not finish
-	output.RenderResults(os.Stdout, results, "What's my hostname?", true)
+	close(res) // we need to close the channel or output.RenderResults will not finish
+	output.RenderResults(os.Stdout, res, "What's my hostname?", true)
 }

--- a/examples/4_advanced_1/output.txt
+++ b/examples/4_advanced_1/output.txt
@@ -1,3 +1,15 @@
+[34m# Connecting to devices via ssh
+[0m[32m@ dev1.group_1
+[0m  - connection opened
+[32m@ dev2.group_1
+[0m  - connection opened
+[32m@ dev3.group_2
+[0m  - connection opened
+[32m@ dev4.group_2
+[0m  - connection opened
+[31m@ dev5.no_group
+[0m  - err: failed to dial: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none password], no supported methods remain
+
 [34m# What's my hostname?
 [0m[32m@ dev1.group_1
 [0m  - stdout: dev1.group_1
@@ -16,5 +28,17 @@
 
   - stderr: 
 [31m@ dev5.no_group
-[0m  - err: failed to dial: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none password], no supported methods remain
+[0m  - err: failed to retrieve connection: couldn't find connection
+
+[34m# Close ssh connection
+[0m[32m@ dev1.group_1
+[0m  - connection closed
+[32m@ dev2.group_1
+[0m  - connection closed
+[32m@ dev3.group_2
+[0m  - connection closed
+[32m@ dev4.group_2
+[0m  - connection closed
+[31m@ dev5.no_group
+[0m  - err: failed to retrieve connection: couldn't find connection
 

--- a/examples/5_advanced_2/main.go
+++ b/examples/5_advanced_2/main.go
@@ -25,6 +25,7 @@ type getHostnameAndIPResult struct {
 	SubResults []gornir.TaskInstanceResult // Result of running various commands
 }
 
+// String implements fmt.Stringer interface. This basically allows us to control the output when printing the object
 func (r getHostnameAndIPResult) String() string {
 	res := ""
 	for _, r := range r.SubResults {
@@ -83,6 +84,7 @@ func main() {
 
 	gr := gornir.New().WithInventory(inv).WithLogger(log).WithRunner(rnr)
 
+	// We need a channel to store the results
 	results := make(chan *gornir.JobResult, len(gr.Inventory.Hosts))
 
 	// The following call will not block

--- a/examples/5_advanced_2/main.go
+++ b/examples/5_advanced_2/main.go
@@ -8,11 +8,64 @@ import (
 	"time"
 
 	"github.com/nornir-automation/gornir/pkg/gornir"
+	"github.com/nornir-automation/gornir/pkg/plugins/connection"
 	"github.com/nornir-automation/gornir/pkg/plugins/inventory"
 	"github.com/nornir-automation/gornir/pkg/plugins/logger"
 	"github.com/nornir-automation/gornir/pkg/plugins/runner"
 	"github.com/nornir-automation/gornir/pkg/plugins/task"
 )
+
+// This is a grouped task, it will allow us to build our own task
+// leveraging other tasks
+type getHostnameAndIP struct {
+}
+
+// This is going to be your task result, you can have whatever you want here
+type getHostnameAndIPResult struct {
+	SubResults []gornir.TaskInstanceResult // Result of running various commands
+}
+
+func (r getHostnameAndIPResult) String() string {
+	res := ""
+	for _, r := range r.SubResults {
+		res += fmt.Sprintf("%s\n", r)
+	}
+	return res
+}
+
+// Here is where you implement your logic
+func (r *getHostnameAndIP) Run(ctx context.Context, logger gornir.Logger, host *gornir.Host) (gornir.TaskInstanceResult, error) {
+	resOpen, err := (&connection.SSHOpen{}).Run(ctx, logger, host)
+	if err != nil {
+		return getHostnameAndIPResult{}, err
+	}
+
+	// We call the first subtask and store the subresult
+	res1, err := (&task.RemoteCommand{Command: "hostname"}).Run(ctx, logger, host)
+	if err != nil {
+		return getHostnameAndIPResult{}, err
+	}
+
+	// We call the second subtask and store the subresult
+	res2, err := (&task.RemoteCommand{Command: "ip addr | grep \\/24 | awk '{ print $2 }'"}).Run(ctx, logger, host)
+	if err != nil {
+		return getHostnameAndIPResult{}, err
+	}
+
+	resClose, err := (&connection.SSHClose{}).Run(ctx, logger, host)
+	if err != nil {
+		return getHostnameAndIPResult{}, err
+	}
+
+	return getHostnameAndIPResult{
+		SubResults: []gornir.TaskInstanceResult{
+			resOpen,
+			res1,
+			res2,
+			resClose,
+		},
+	}, nil
+}
 
 func main() {
 	// Instantiate a logger plugin
@@ -35,7 +88,7 @@ func main() {
 	// The following call will not block
 	err = gr.RunAsync(
 		context.Background(),
-		&task.RemoteCommand{Command: "hostname"},
+		&getHostnameAndIP{},
 		results,
 	)
 	if err != nil {
@@ -62,7 +115,7 @@ func main() {
 			if res.Err() != nil {
 				fmt.Printf("ERROR: %s: %s\n", res.Host().Hostname, res.Err().Error())
 			} else {
-				fmt.Printf("OK: %s: %s\n", res.Host().Hostname, res.Data().(task.RemoteCommandResults).Stdout)
+				fmt.Printf("OK: %s:\n%s\n", res.Host().Hostname, res.Data().(gornir.TaskInstanceResult))
 			}
 		case <-time.After(time.Second * 10):
 			return

--- a/examples/5_advanced_2/output.txt
+++ b/examples/5_advanced_2/output.txt
@@ -1,9 +1,41 @@
-OK: dev1.group_1: dev1.group_1
+OK: dev1.group_1:
+  - connection opened
+  - stdout: dev1.group_1
 
-OK: dev2.group_1: dev2.group_1
+  - stderr: 
+  - stdout: 10.21.33.101/24
 
-OK: dev3.group_2: dev3.group_2
+  - stderr: 
+  - connection closed
 
-OK: dev4.group_2: dev4.group_2
+OK: dev2.group_1:
+  - connection opened
+  - stdout: dev2.group_1
+
+  - stderr: 
+  - stdout: 10.21.33.102/24
+
+  - stderr: 
+  - connection closed
+
+OK: dev3.group_2:
+  - connection opened
+  - stdout: dev3.group_2
+
+  - stderr: 
+  - stdout: 10.21.33.103/24
+
+  - stderr: 
+  - connection closed
+
+OK: dev4.group_2:
+  - connection opened
+  - stdout: dev4.group_2
+
+  - stderr: 
+  - stdout: 10.21.33.104/24
+
+  - stderr: 
+  - connection closed
 
 ERROR: dev5.no_group: failed to dial: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none password], no supported methods remain

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,9 @@ require (
 	github.com/google/go-cmp v0.3.0
 	github.com/google/uuid v1.1.1
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/kr/fs v0.1.0 // indirect
 	github.com/pkg/errors v0.8.1
+	github.com/pkg/sftp v1.10.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,12 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
+github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/sftp v1.10.0 h1:DGA1KlA9esU6WcicH+P8PxFZOl15O6GYtab1cIJdOlE=
+github.com/pkg/sftp v1.10.0/go.mod h1:NxmoDg/QLVWluQDUYG7XBZTLUpKeFa8e3aMf1BfjyHk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=

--- a/pkg/gornir/connection.go
+++ b/pkg/gornir/connection.go
@@ -1,5 +1,6 @@
 package gornir
 
+// Connection defines an interface to write connection tasks
 type Connection interface {
-	Close() error
+	Close() error // Close closes the connection
 }

--- a/pkg/gornir/connection.go
+++ b/pkg/gornir/connection.go
@@ -1,0 +1,4 @@
+package gornir
+
+type Connection interface {
+}

--- a/pkg/gornir/inventory.go
+++ b/pkg/gornir/inventory.go
@@ -47,6 +47,7 @@ func (h *Host) Err() error {
 	return h.err
 }
 
+// SetConnections stores a connection
 func (h *Host) SetConnection(name string, conn Connection) {
 	if h.connections == nil {
 		h.connections = make(map[string]Connection)
@@ -54,6 +55,7 @@ func (h *Host) SetConnection(name string, conn Connection) {
 	h.connections[name] = conn
 }
 
+// GetConnection retrieves a connection that was previously set
 func (h *Host) GetConnection(name string) (Connection, error) {
 	if h.connections == nil {
 		h.connections = make(map[string]Connection)

--- a/pkg/gornir/inventory.go
+++ b/pkg/gornir/inventory.go
@@ -1,13 +1,18 @@
 package gornir
 
+import (
+	"github.com/pkg/errors"
+)
+
 // Host represent a host
 type Host struct {
-	err      error
-	Port     uint8  `yaml:"port"`     // Port to connect to
-	Hostname string `yaml:"hostname"` // Hostname/FQDN/IP to connect to
-	Username string `yaml:"username"` // Username to use for authentication purposes
-	Password string `yaml:"password"` // Password to use for authentication purposes
-	Platform string `yaml:"platform"` // Platform of the device
+	err         error
+	Port        uint8  `yaml:"port"`     // Port to connect to
+	Hostname    string `yaml:"hostname"` // Hostname/FQDN/IP to connect to
+	Username    string `yaml:"username"` // Username to use for authentication purposes
+	Password    string `yaml:"password"` // Password to use for authentication purposes
+	Platform    string `yaml:"platform"` // Platform of the device
+	connections map[string]Connection
 }
 
 // Inventory represents a collection of Hosts
@@ -40,4 +45,21 @@ func (h *Host) SetErr(err error) {
 // Err returns the stored error
 func (h *Host) Err() error {
 	return h.err
+}
+
+func (h *Host) SetConnection(name string, conn Connection) {
+	if h.connections == nil {
+		h.connections = make(map[string]Connection)
+	}
+	h.connections[name] = conn
+}
+
+func (h *Host) GetConnection(name string) (Connection, error) {
+	if h.connections == nil {
+		return nil, errors.New("there are no connection established")
+	}
+	if c, ok := h.connections[name]; ok {
+		return c, nil
+	}
+	return nil, errors.New("couldn't find connection")
 }

--- a/pkg/gornir/runner.go
+++ b/pkg/gornir/runner.go
@@ -28,7 +28,7 @@ type JobResult struct {
 	ctx  context.Context
 	err  error
 	host *Host
-	data interface{}
+	data TaskInstanceResult
 }
 
 // NewJobResult instantiates a new JobResult

--- a/pkg/plugins/connection/connection.go
+++ b/pkg/plugins/connection/connection.go
@@ -1,0 +1,1 @@
+package connection

--- a/pkg/plugins/connection/connection.go
+++ b/pkg/plugins/connection/connection.go
@@ -1,1 +1,2 @@
+// Package connection implements various Connection plugins that can be run over Hosts
 package connection

--- a/pkg/plugins/connection/ssh.go
+++ b/pkg/plugins/connection/ssh.go
@@ -1,0 +1,70 @@
+package connection
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/nornir-automation/gornir/pkg/gornir"
+
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh"
+)
+
+type SSH struct {
+	Client *ssh.Client
+}
+
+type SSHOpen struct {
+}
+
+func (s *SSHOpen) Run(ctx context.Context, wg *sync.WaitGroup, jp *gornir.JobParameters, jobResult chan *gornir.JobResult) {
+	defer wg.Done()
+	host := jp.Host()
+	result := gornir.NewJobResult(ctx, jp)
+
+	sshConfig := &ssh.ClientConfig{
+		User: host.Username,
+		Auth: []ssh.AuthMethod{
+			ssh.Password(host.Password),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	} // #nosec
+	port := host.Port
+	if port == 0 {
+		port = 22
+	}
+	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", host.Hostname, port), sshConfig)
+	if err != nil {
+		result.SetErr(errors.Wrap(err, "failed to dial"))
+		jobResult <- result
+		return
+	}
+
+	jp.Host().SetConnection("ssh", &SSH{client})
+	jobResult <- result
+}
+
+type SSHClose struct {
+}
+
+func (s *SSHClose) Run(ctx context.Context, wg *sync.WaitGroup, jp *gornir.JobParameters, jobResult chan *gornir.JobResult) {
+	defer wg.Done()
+	host := jp.Host()
+	result := gornir.NewJobResult(ctx, jp)
+
+	conn, err := host.GetConnection("ssh")
+	if err != nil {
+		result.SetErr(errors.Wrap(err, "failed to retrieve connection"))
+		jobResult <- result
+		return
+	}
+	sshConn := conn.(*SSH)
+
+	if err := sshConn.Client.Close(); err != nil {
+		result.SetErr(errors.Wrap(err, "failed to close client"))
+		jobResult <- result
+		return
+	}
+	jobResult <- result
+}

--- a/pkg/plugins/connection/ssh.go
+++ b/pkg/plugins/connection/ssh.go
@@ -10,10 +10,14 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// SSH is a Connection plugins that connects to device via ss using the golang.org/x/crypto/ssh
+// package. Current implementation only supports authentication with a password and has
+// ssh.InsecureIgnoreHostKey set
 type SSH struct {
 	Client *ssh.Client
 }
 
+// Close closes the connection
 func (s *SSH) Close() error {
 	return s.Client.Close()
 }
@@ -26,9 +30,11 @@ func (s SSH) String() string {
 	return "  - connection opened"
 }
 
+// SSHOpen is a Connection plugin that opens a connection with a device
 type SSHOpen struct {
 }
 
+// Run implements gornir.Task interface
 func (r *SSHOpen) Run(ctx context.Context, logger gornir.Logger, host *gornir.Host) (gornir.TaskInstanceResult, error) {
 	sshConfig := &ssh.ClientConfig{
 		User: host.Username,
@@ -49,9 +55,11 @@ func (r *SSHOpen) Run(ctx context.Context, logger gornir.Logger, host *gornir.Ho
 	return &SSH{client}, nil
 }
 
+// SSHClose is a Connection plugin that closes an already opened ssh connection
 type SSHClose struct {
 }
 
+// Run implements gornir.Task interface
 func (r *SSHClose) Run(ctx context.Context, logger gornir.Logger, host *gornir.Host) (gornir.TaskInstanceResult, error) {
 	conn, err := host.GetConnection("ssh")
 	if err != nil {

--- a/pkg/plugins/task/sftp.go
+++ b/pkg/plugins/task/sftp.go
@@ -14,13 +14,15 @@ import (
 	"github.com/pkg/errors"
 )
 
+// SFTPUpload will open a new SFTP session on an already opened ssh and upload a file
 type SFTPUpload struct {
 	Src string
 	Dst string
 }
 
+// SFTPUploadResult is the result of calling SFTPUpload
 type SFTPUploadResult struct {
-	Bytes int64
+	Bytes int64 // Bytes written
 }
 
 // String implemente Stringer interface
@@ -28,6 +30,7 @@ func (s SFTPUploadResult) String() string {
 	return fmt.Sprintf("  - uploaded: %d bytes", s.Bytes)
 }
 
+// Run implements will upload a file via sftp
 func (s *SFTPUpload) Run(ctx context.Context, logger gornir.Logger, host *gornir.Host) (gornir.TaskInstanceResult, error) {
 	conn, err := host.GetConnection("ssh")
 	if err != nil {

--- a/pkg/plugins/task/sftp.go
+++ b/pkg/plugins/task/sftp.go
@@ -1,0 +1,70 @@
+package task
+
+import (
+	"context"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/pkg/sftp"
+
+	"github.com/nornir-automation/gornir/pkg/gornir"
+	"github.com/nornir-automation/gornir/pkg/plugins/connection"
+
+	"github.com/pkg/errors"
+)
+
+type SFTPUpload struct {
+	Src string
+	Dst string
+}
+
+type SFTPUploadResult struct {
+	Bytes int64
+}
+
+func (s *SFTPUpload) Run(ctx context.Context, wg *sync.WaitGroup, jp *gornir.JobParameters, jobResult chan *gornir.JobResult) {
+	defer wg.Done()
+	host := jp.Host()
+	result := gornir.NewJobResult(ctx, jp)
+
+	conn, err := host.GetConnection("ssh")
+	if err != nil {
+		result.SetErr(errors.Wrap(err, "failed to retrieve connection"))
+		jobResult <- result
+		return
+	}
+	sshConn := conn.(*connection.SSH)
+
+	client, err := sftp.NewClient(sshConn.Client)
+	if err != nil {
+		result.SetErr(errors.Wrap(err, "failed to create sftp client"))
+		jobResult <- result
+		return
+	}
+	defer client.Close()
+
+	dstFile, err := client.Create(s.Dst)
+	if err != nil {
+		result.SetErr(errors.Wrap(err, "failed to create destination file"))
+		jobResult <- result
+		return
+	}
+	defer dstFile.Close()
+
+	srcFile, err := os.Open(s.Src)
+	if err != nil {
+		result.SetErr(errors.Wrap(err, "failed to open source file"))
+		jobResult <- result
+		return
+	}
+
+	bytes, err := io.Copy(dstFile, srcFile)
+	if err != nil {
+		result.SetErr(errors.Wrap(err, "problem uploading file"))
+		jobResult <- result
+		return
+	}
+	result.SetData(SFTPUploadResult{bytes})
+	jobResult <- result
+}

--- a/pkg/plugins/task/ssh.go
+++ b/pkg/plugins/task/ssh.go
@@ -11,12 +11,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-// RemoteCommand will connect to the Host via ssh and execute the given command
+// RemoteCommand will open a new Session on an already opened ssh connection and execute the given command
 type RemoteCommand struct {
 	Command string // Command to execute
 }
 
-// RemoteCommandResults will be accessible via JobResult.Data()
+// RemoteCommandResults is the result of calling RemoteCommand
 type RemoteCommandResults struct {
 	Stdout []byte // Stdout written by the command
 	Stderr []byte // Stderr written by the command


### PR DESCRIPTION
This is WIP as it needs some cleaning and discuss certain things. In any case, this PR tries to illustrate a few points:

1. A task-like struct (connection.SSHOpen) can establish a connection with a device and store it for further use.
2. Another task-like struct (connection.SSHClose) closes such connection.
3. Tasks can now retrieve these "connections" and reuse them as needed. For instance, I added an sftp task that can reuse the same ssh connection that was already established to upload files.

In the example_1, which I edited to illustrate this, you can see how the same ssh connection can be used to execute multiple commands and to upload a file.

@Ali-aqrabawi take a look at this, if you implemented a similar interface like Sftp library does we could reuse the same ssh connection.

Another advantage of this method is that if the *Open method doesn't satisfy your needs because you have a more complex setup you can use your own method and the tasks will still be able to use the connection established by your custom method.