### PR TITLE
Clean up Makefile a bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 PROJECT="github.com/nornir-automation/gornir"
 GOLANGCI_LINT_VER="v1.17"
+.DEFAULT_GOAL := help
 
-.PHONY: tests
-tests:
+.PHONY: tests lint godoc
+tests: ## Run Go test tool
 	go test -v ./... -coverprofile=coverage.txt -covermode=atomic
 
-.PHONY: lint
-lint:
+lint: ## Run Go linters in a Docker container
 	docker run \
 		--rm \
 		-v $(PWD):/go/src/$(PROJECT) \
@@ -16,7 +16,6 @@ lint:
 		golangci/golangci-lint:$(GOLANGCI_LINT_VER) \
 			golangci-lint run
 
-.PHONY: test-suite
 test-suite:
 ifeq ($(TEST_SUITE),unit)
 	make tests
@@ -28,32 +27,25 @@ else
 	echo "I don't know what '$(TEST_SUITE)' means"
 endif
 
-.PHONY: start-dev-env
-start-dev-env:
+start-dev-env: ## Create a development enviroment
 	docker-compose up -d
 
-.PHONY: stop-dev-env
-stop-dev-env:
+stop-dev-env: ## Bring down the development enviroment
 	docker-compose down
 
-.PHONY: example
-example:
+example: ## Run a given example
 	docker-compose run gornir \
 		go run /go/src/github.com/nornir-automation/gornir/examples/$(EXAMPLE)/main.go
 
-.PHONY: godoc
-godoc:
+godoc: ## Run Go Docs in a container in port 6060
 	docker-compose run -p 6060:6060 gornir \
 		godoc -http 0.0.0.0:6060 -v
 
-
-.PHONY: test-example
-test-example:
+test-example: ## Check example output changes
 	docker-compose run gornir \
 		go run /go/src/github.com/nornir-automation/gornir/examples/$(EXAMPLE)/main.go > examples/$(EXAMPLE)/output.txt
 	git diff --exit-code examples/$(EXAMPLE)/output.txt
 
-.PHONY: _test-examples
 _test-examples:
 	# not super proud but we run it twice because sometimes the order of the
 	# auth methods change causing the error of dev5 to be slightly different
@@ -64,5 +56,7 @@ _test-examples:
 	make test-example EXAMPLE=4_advanced_1 || make test-example EXAMPLE=4_advanced_1
 	make test-example EXAMPLE=5_advanced_2 || make test-example EXAMPLE=5_advanced_2
 
-.PHONY: test-examples
 test-examples: start-dev-env _test-examples stop-dev-env
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@ PROJECT="github.com/nornir-automation/gornir"
 GOLANGCI_LINT_VER="v1.17"
 .DEFAULT_GOAL := help
 
-.PHONY: tests lint godoc
+.PHONY: tests
 tests: ## Run Go test tool
 	go test -v ./... -coverprofile=coverage.txt -covermode=atomic
 
+.PHONY: lint
 lint: ## Run Go linters in a Docker container
 	docker run \
 		--rm \
@@ -16,6 +17,7 @@ lint: ## Run Go linters in a Docker container
 		golangci/golangci-lint:$(GOLANGCI_LINT_VER) \
 			golangci-lint run
 
+.PHONY: test-suite
 test-suite:
 ifeq ($(TEST_SUITE),unit)
 	make tests
@@ -27,25 +29,31 @@ else
 	echo "I don't know what '$(TEST_SUITE)' means"
 endif
 
+.PHONY: start-dev-env
 start-dev-env: ## Create a development enviroment
 	docker-compose up -d
 
+.PHONY: stop-dev-env
 stop-dev-env: ## Bring down the development enviroment
 	docker-compose down
 
+.PHONY: example
 example: ## Run a given example
 	docker-compose run gornir \
 		go run /go/src/github.com/nornir-automation/gornir/examples/$(EXAMPLE)/main.go
 
+.PHONY: godoc
 godoc: ## Run Go Docs in a container in port 6060
 	docker-compose run -p 6060:6060 gornir \
 		godoc -http 0.0.0.0:6060 -v
 
+.PHONY: test-example
 test-example: ## Check example output changes
 	docker-compose run gornir \
 		go run /go/src/github.com/nornir-automation/gornir/examples/$(EXAMPLE)/main.go > examples/$(EXAMPLE)/output.txt
 	git diff --exit-code examples/$(EXAMPLE)/output.txt
 
+.PHONY: _test-examples
 _test-examples:
 	# not super proud but we run it twice because sometimes the order of the
 	# auth methods change causing the error of dev5 to be slightly different
@@ -56,7 +64,9 @@ _test-examples:
 	make test-example EXAMPLE=4_advanced_1 || make test-example EXAMPLE=4_advanced_1
 	make test-example EXAMPLE=5_advanced_2 || make test-example EXAMPLE=5_advanced_2
 
+.PHONY: test-examples
 test-examples: start-dev-env _test-examples stop-dev-env
 
+.PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
I'm not an expert on Makefiles, but wanted to propose a few tweaks.

1. Not everything is a `PHONY` (we probably won't end up with a file with the name of the target). 

2. Group the `PHONY` in a single line. To me feels simpler to follow, but this is really a personal preference.

3. Add a help function and comments, so we can do this (idea from [here](https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html)):

```bash
$ make
example                        Run a given example
godoc                          Run Go Docs in a container in port 6060
lint                           Run Go linters in a Docker container
start-dev-env                  Create a development enviroment
stop-dev-env                   Bring down the development enviroment
test-example                   Check example output changes
tests                          Run Go test tool
```


